### PR TITLE
Add sbpl to dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -33,6 +33,7 @@
   <!-- Examples: -->
   <!-- Use build_depend for packages you need at compile time: -->
   <!--   <build_depend>message_generation</build_depend> -->
+  <build_depend>sbpl</build_depend>
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
   <!-- Use run_depend for packages you need at runtime: -->


### PR DESCRIPTION
By adding the dependencies to the `package.xml`, rosdep can be used to install them automatically.